### PR TITLE
Fix Ansible sendall() error

### DIFF
--- a/tasks/call_script.yml
+++ b/tasks/call_script.yml
@@ -9,4 +9,4 @@
     method: POST
     status_code: 200,204
     force_basic_auth: yes
-    body: "{{ args | to_json }}"
+    body: " {{ args | to_json }}"


### PR DESCRIPTION
Hello,

Without this space, Ansible (2.1.0) return this error:
'sendall() argument 1 must be string or buffer, not dict'