### PR TITLE
Max File Descriptors as a parameter so that we can increase it if needed

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,6 +5,7 @@ nexus_download_dir: '/tmp'
 nexus_backup_dir: '/var/nexus-backup'
 nexus_os_group: 'nexus'
 nexus_os_user: 'nexus'
+nexus_os_max_filedescriptors: 65536 # nexus > 3.5.x issues a warning on lower value. Next versions might not boot at all
 nexus_installation_dir: '/opt'
 nexus_data_dir: '/var/nexus'
 nexus_timezone: 'UTC' # java timezone

--- a/templates/nexus.service
+++ b/templates/nexus.service
@@ -4,7 +4,7 @@ After=network.target
 
 [Service]
 Type=forking
-LimitNOFILE=65536
+LimitNOFILE={{ nexus_os_max_filedescriptors }}
 ExecStart={{ nexus_installation_dir }}/nexus-latest/bin/nexus start
 ExecStop={{ nexus_installation_dir }}/nexus-latest/bin/nexus stop
 User={{ nexus_os_user }}


### PR DESCRIPTION
This might come in handy on huge repositories. Moreover, it adds a comment and param in defaults for self doc.