### PR TITLE
Symlinking backup/restore scripts to /sbin fails

### DIFF
--- a/tasks/nexus_install.yml
+++ b/tasks/nexus_install.yml
@@ -171,22 +171,25 @@
 # - name: Enable nexus service
 #   systemd: name=nexus daemon_reload=yes enabled=yes state=started
 
+- name: "Register scripts to be deployed"
+  set_fact:
+    nexus_deployed_scripts:
+      - nexus-blob-backup.sh
+      - nexus-blob-restore.sh
+
 - name: "Deploy scripts"
   template:
     src: "{{ item }}.j2"
     dest: "{{ nexus_script_dir }}/{{ item }}"
     mode: 0755
-  with_items:
-    - nexus-blob-backup.sh
-    - nexus-blob-restore.sh
+  with_items: "{{ nexus_deployed_scripts }}"
 
 - name: "Symlink scripts to /sbin"
   file:
-    src: "{{ item }}"
-    dest: "/sbin/{{ item | basename }}"
+    src: "{{ nexus_script_dir }}/{{ item }}"
+    dest: "/sbin/{{ item }}"
     state: link
-  with_fileglob:
-    - "{{ nexus_script_dir }}/*.sh"
+  with_items: "{{ nexus_deployed_scripts }}"
 
 - name: 'Check if data directory is empty (first-time install)'
   command: "ls {{ nexus_data_dir }}"


### PR DESCRIPTION
Symlinking scripts systematically fails with

`[WARNING]: Unable to find '/opt/nexus-<version>/etc/scripts' in expected paths.`

Reason:
with_fileglob operates on the local machine, not on the remote host.