### PR TITLE
Adding security realms activation task

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -37,6 +37,7 @@ nexus_nuget_api_key_realm: false
 nexus_npm_bearer_token_realm: false
 nexus_rut_auth_realm: false
 nexus_ldap_realm: false
+nexus_docker_bearer_token_realm: false
 
 nexus_branding_header: ""
 nexus_branding_footer: "Last provisionned {{ ansible_date_time.iso8601 }}"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -32,6 +32,12 @@ nexus_anonymous_access: false
 
 public_hostname: 'nexus.vm'
 
+# security realms
+nexus_nuget_api_key_realm: false
+nexus_npm_bearer_token_realm: false
+nexus_rut_auth_realm: false
+nexus_ldap_realm: false
+
 nexus_branding_header: ""
 nexus_branding_footer: "Last provisionned {{ ansible_date_time.iso8601 }}"
 

--- a/files/groovy/setup_realms.groovy
+++ b/files/groovy/setup_realms.groovy
@@ -1,0 +1,18 @@
+import groovy.json.JsonSlurper
+import org.sonatype.nexus.security.realm.RealmManager
+
+parsed_args = new JsonSlurper().parseText(args)
+
+realmManager = container.lookup(RealmManager.class.getName())
+
+// enable/disable the NuGet API-Key Realm
+realmManager.enableRealm("NuGetApiKey", parsed_args.nuget_api_key_realm)
+
+// enable/disable the npm Bearer Token Realm
+realmManager.enableRealm("NpmToken", parsed_args.npm_bearer_token_realm)
+
+// enable/disable the Rut Auth Realm
+realmManager.enableRealm("rutauth-realm", parsed_args.rut_auth_realm)
+
+// enable/disable the LDAP Realm
+realmManager.enableRealm("LdapRealm", parsed_args.ldap_realm)

--- a/files/groovy/setup_realms.groovy
+++ b/files/groovy/setup_realms.groovy
@@ -16,3 +16,6 @@ realmManager.enableRealm("rutauth-realm", parsed_args.rut_auth_realm)
 
 // enable/disable the LDAP Realm
 realmManager.enableRealm("LdapRealm", parsed_args.ldap_realm)
+
+// enable/disable the Docker Bearer Token Realm
+realmManager.enableRealm("DockerToken", parsed_args.docker_bearer_token_realm)

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -150,6 +150,15 @@
     args:
       base_url: "https://{{ public_hostname }}/"
 
+- include: call_script.yml
+  vars:
+    script_name: setup_realms
+    args:
+      nuget_api_key_realm: "{{ nexus_nuget_api_key_realm }}"
+      npm_bearer_token_realm: "{{ nexus_npm_bearer_token_realm }}"
+      rut_auth_realm: "{{ nexus_rut_auth_realm }}"
+      ldap_realm: "{{ nexus_ldap_realm }}"
+
 - name: Configure branding capability
   include: call_script.yml
   vars:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -158,6 +158,7 @@
       npm_bearer_token_realm: "{{ nexus_npm_bearer_token_realm }}"
       rut_auth_realm: "{{ nexus_rut_auth_realm }}"
       ldap_realm: "{{ nexus_ldap_realm }}"
+      docker_bearer_token_realm: "{{ nexus_docker_bearer_token_realm }}"
 
 - name: Configure branding capability
   include: call_script.yml

--- a/tasks/nexus_install.yml
+++ b/tasks/nexus_install.yml
@@ -257,6 +257,7 @@
     - setup_role
     - setup_privilege
     - setup_user
+    - setup_realms
     - delete_repo
     - delete_blobstore
     - create_blobstore


### PR DESCRIPTION
This PR allows the activation of various security realms:

- `NuGet API-Key Realm` [`nexus_nuget_api_key_realm: true|false`]
- `npm Bearer Token Realm` [`nexus_npm_bearer_token_realm: true|false`]
- `LDAP Realm` [`nexus_ldap_realm: true|false`]
- `Rut Auth Realm` [`nexus_rut_auth_realm: true|false`]
- `Docker Bearer Token Realm` [`nexus_docker_bearer_token_realm: true|false`] (Nexus v3.6.0)