### PR TITLE
Allow disabling authentication for Docker anonymous pull (Nexus 3.6.0)

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -232,6 +232,7 @@ nexus_repos_raw_group:
 # Docker support
 _nexus_repos_docker_defaults:
   blob_store: "{{ nexus_blob_names.docker.blob }}"
+  force_basic_auth: true
   strict_content_validation: true
   version_policy: release # release, snapshot or mixed
   layout_policy: strict # strict or permissive

--- a/files/groovy/create_repo_docker_group.groovy
+++ b/files/groovy/create_repo_docker_group.groovy
@@ -9,6 +9,7 @@ configuration = new Configuration(
         online: true,
         attributes: [
                 docker: [
+                        forceBasicAuth: parsed_args.force_basic_auth,
                         httpPort: parsed_args.http_port,
                         v1Enabled : parsed_args.v1_enabled
                 ],

--- a/files/groovy/create_repo_docker_hosted.groovy
+++ b/files/groovy/create_repo_docker_hosted.groovy
@@ -9,6 +9,7 @@ configuration = new Configuration(
         online: true,
         attributes: [
                 docker: [
+                        forceBasicAuth: parsed_args.force_basic_auth,
                         httpPort: parsed_args.http_port,
                         v1Enabled : parsed_args.v1_enabled
                 ],

--- a/files/groovy/create_repo_docker_proxy.groovy
+++ b/files/groovy/create_repo_docker_proxy.groovy
@@ -9,6 +9,7 @@ configuration = new Configuration(
         online: true,
         attributes: [
                 docker: [
+                        forceBasicAuth: parsed_args.force_basic_auth,
                         httpPort: parsed_args.http_port,
                         v1Enabled : parsed_args.v1_enabled
                 ],


### PR DESCRIPTION
This PR allows disabling the basic authentication in order to support the new Docker Anonymous Pull feature implemented in Nexus 3.6.0 ([NEXUS-10813](https://issues.sonatype.org/browse/NEXUS-10813))

Setting `force_basic_auth: false` will allow anonymous pull.

In addition, the Docker Bearer Token Realm must be activated, PR https://github.com/savoirfairelinux/ansible-nexus3-oss/pull/26 was updated to allow configuring this too.