### PR TITLE
Make docker http connector port optional

### DIFF
--- a/files/groovy/create_repo_docker_group.groovy
+++ b/files/groovy/create_repo_docker_group.groovy
@@ -9,7 +9,6 @@ configuration = new Configuration(
         online: true,
         attributes: [
                 docker: [
-                        httpPort: parsed_args.http_port,
                         v1Enabled : parsed_args.v1_enabled
                 ],
                 group: [
@@ -22,6 +21,10 @@ configuration = new Configuration(
                 ]
         ]
 )
+
+if (parsed_args.http_port) {
+    configuration.attributes['docker']['httpPort'] = parsed_args.http_port
+}
 
 def existingRepository = repository.getRepositoryManager().get(parsed_args.name)
 

--- a/files/groovy/create_repo_docker_hosted.groovy
+++ b/files/groovy/create_repo_docker_hosted.groovy
@@ -9,7 +9,6 @@ configuration = new Configuration(
         online: true,
         attributes: [
                 docker: [
-                        httpPort: parsed_args.http_port,
                         v1Enabled : parsed_args.v1_enabled
                 ],
                 storage: [
@@ -19,6 +18,10 @@ configuration = new Configuration(
                 ]
         ]
 )
+
+if (parsed_args.http_port) {
+    configuration.attributes['docker']['httpPort'] = parsed_args.http_port
+}
 
 def existingRepository = repository.getRepositoryManager().get(parsed_args.name)
 

--- a/files/groovy/create_repo_docker_proxy.groovy
+++ b/files/groovy/create_repo_docker_proxy.groovy
@@ -9,7 +9,6 @@ configuration = new Configuration(
         online: true,
         attributes: [
                 docker: [
-                        httpPort: parsed_args.http_port,
                         v1Enabled : parsed_args.v1_enabled
                 ],
                 proxy: [
@@ -35,6 +34,10 @@ configuration = new Configuration(
                 ]
         ]
 )
+
+if (parsed_args.http_port) {
+    configuration.attributes['docker']['httpPort'] = parsed_args.http_port
+}
 
 def existingRepository = repository.getRepositoryManager().get(parsed_args.name)
 


### PR DESCRIPTION
if the `http_port` is not set, the connector port will not be configured.

This is relevant when some repositories don't need to be exposed directly, but via a group.