### PR TITLE
[WIP] Remove include warnings in ansible 2.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ All configuration can be updated by re-running the role, except for the [blobsto
 
 ## Requirements
 
+- Ansible 2.4 or later
 - This has only been tested on CentOS 7 + Ubuntu 16.04 (Xenial)
 - Oracle Java 8 (mandatory)
 - Apache HTTPD (optional, used to setup a SSL reverse-proxy)

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ All configuration can be updated by re-running the role, except for the [blobsto
 
 ## Requirements
 
-- Ansible 2.4 or later
+- Ansible 2.4 or later (see meta/main.yml)
 - This has only been tested on CentOS 7 + Ubuntu 16.04 (Xenial)
 - Oracle Java 8 (mandatory)
 - Apache HTTPD (optional, used to setup a SSL reverse-proxy)

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -5,7 +5,7 @@ galaxy_info:
 
   license: license (GPLv3)
 
-  min_ansible_version: 2.1
+  min_ansible_version: 2.4
 
   github_branch: master
 

--- a/tasks/admin_password_setup.yml
+++ b/tasks/admin_password_setup.yml
@@ -1,5 +1,5 @@
 ---
-- include: call_script.yml
+- import_tasks: call_script.yml
   vars:
     script_name: update_admin_password
     args:

--- a/tasks/create_blobstore_each.yml
+++ b/tasks/create_blobstore_each.yml
@@ -7,7 +7,7 @@
     state: directory
     recurse: true
 
-- include: call_script.yml
+- import_tasks: call_script.yml
   vars:
     script_name: create_blobstore
     args: "{{ item }}"

--- a/tasks/create_repo_bower_group_each.yml
+++ b/tasks/create_repo_bower_group_each.yml
@@ -1,5 +1,5 @@
 ---
-- include: call_script.yml
+- import_tasks: call_script.yml
   vars:
     script_name: create_repo_bower_group
     args: "{{ _nexus_repos_bower_defaults|combine(item) }}"

--- a/tasks/create_repo_bower_hosted_each.yml
+++ b/tasks/create_repo_bower_hosted_each.yml
@@ -1,5 +1,5 @@
 ---
-- include: call_script.yml
+- import_tasks: call_script.yml
   vars:
     script_name: create_repo_bower_hosted
     args: "{{ _nexus_repos_bower_defaults|combine(item) }}"

--- a/tasks/create_repo_bower_proxy_each.yml
+++ b/tasks/create_repo_bower_proxy_each.yml
@@ -1,5 +1,5 @@
 ---
-- include: call_script.yml
+- import_tasks: call_script.yml
   vars:
     script_name: create_repo_bower_proxy
     args: "{{ _nexus_repos_bower_defaults|combine(item) }}"

--- a/tasks/create_repo_docker_group_each.yml
+++ b/tasks/create_repo_docker_group_each.yml
@@ -1,5 +1,5 @@
 ---
-- include: call_script.yml
+- import_tasks: call_script.yml
   vars:
     script_name: create_repo_docker_group
     args: "{{ _nexus_repos_docker_defaults|combine(item) }}"

--- a/tasks/create_repo_docker_hosted_each.yml
+++ b/tasks/create_repo_docker_hosted_each.yml
@@ -1,5 +1,5 @@
 ---
-- include: call_script.yml
+- import_tasks: call_script.yml
   vars:
     script_name: create_repo_docker_hosted
     args: "{{ _nexus_repos_docker_defaults|combine(item) }}"

--- a/tasks/create_repo_docker_proxy_each.yml
+++ b/tasks/create_repo_docker_proxy_each.yml
@@ -1,5 +1,5 @@
 ---
-- include: call_script.yml
+- import_tasks: call_script.yml
   vars:
     script_name: create_repo_docker_proxy
     args: "{{ _nexus_repos_docker_defaults|combine(item) }}"

--- a/tasks/create_repo_gitlfs_hosted_each.yml
+++ b/tasks/create_repo_gitlfs_hosted_each.yml
@@ -1,5 +1,5 @@
 ---
-- include: call_script.yml
+- import_tasks: call_script.yml
   vars:
     script_name: create_repo_gitlfs_hosted
     args: "{{ _nexus_repos_gitlfs_defaults|combine(item) }}"

--- a/tasks/create_repo_maven_group_each.yml
+++ b/tasks/create_repo_maven_group_each.yml
@@ -1,5 +1,5 @@
 ---
-- include: call_script.yml
+- import_tasks: call_script.yml
   vars:
     script_name: create_repo_maven_group
     args: "{{ _nexus_repos_maven_defaults|combine(item) }}"

--- a/tasks/create_repo_maven_hosted_each.yml
+++ b/tasks/create_repo_maven_hosted_each.yml
@@ -1,5 +1,5 @@
 ---
-- include: call_script.yml
+- import_tasks: call_script.yml
   vars:
     script_name: create_repo_maven_hosted
     args: "{{ _nexus_repos_maven_defaults|combine(item) }}"

--- a/tasks/create_repo_maven_proxy_each.yml
+++ b/tasks/create_repo_maven_proxy_each.yml
@@ -1,5 +1,5 @@
 ---
-- include: call_script.yml
+- import_tasks: call_script.yml
   vars:
     script_name: create_repo_maven_proxy
     args: "{{ _nexus_repos_maven_defaults|combine(item) }}"

--- a/tasks/create_repo_npm_group_each.yml
+++ b/tasks/create_repo_npm_group_each.yml
@@ -1,5 +1,5 @@
 ---
-- include: call_script.yml
+- import_tasks: call_script.yml
   vars:
     script_name: create_repo_npm_group
     args: "{{ _nexus_repos_npm_defaults|combine(item) }}"

--- a/tasks/create_repo_npm_hosted_each.yml
+++ b/tasks/create_repo_npm_hosted_each.yml
@@ -1,5 +1,5 @@
 ---
-- include: call_script.yml
+- import_tasks: call_script.yml
   vars:
     script_name: create_repo_npm_hosted
     args: "{{ _nexus_repos_npm_defaults|combine(item) }}"

--- a/tasks/create_repo_npm_proxy_each.yml
+++ b/tasks/create_repo_npm_proxy_each.yml
@@ -1,5 +1,5 @@
 ---
-- include: call_script.yml
+- import_tasks: call_script.yml
   vars:
     script_name: create_repo_npm_proxy
     args: "{{ _nexus_repos_npm_defaults|combine(item) }}"

--- a/tasks/create_repo_pypi_group_each.yml
+++ b/tasks/create_repo_pypi_group_each.yml
@@ -1,5 +1,5 @@
 ---
-- include: call_script.yml
+- import_tasks: call_script.yml
   vars:
     script_name: create_repo_pypi_group
     args: "{{ _nexus_repos_pypi_defaults|combine(item) }}"

--- a/tasks/create_repo_pypi_hosted_each.yml
+++ b/tasks/create_repo_pypi_hosted_each.yml
@@ -1,5 +1,5 @@
 ---
-- include: call_script.yml
+- import_tasks: call_script.yml
   vars:
     script_name: create_repo_pypi_hosted
     args: "{{ _nexus_repos_pypi_defaults|combine(item) }}"

--- a/tasks/create_repo_pypi_proxy_each.yml
+++ b/tasks/create_repo_pypi_proxy_each.yml
@@ -1,5 +1,5 @@
 ---
-- include: call_script.yml
+- import_tasks: call_script.yml
   vars:
     script_name: create_repo_pypi_proxy
     args: "{{ _nexus_repos_pypi_defaults|combine(item) }}"

--- a/tasks/create_repo_raw_group_each.yml
+++ b/tasks/create_repo_raw_group_each.yml
@@ -1,5 +1,5 @@
 ---
-- include: call_script.yml
+- import_tasks: call_script.yml
   vars:
     script_name: create_repo_raw_group
     args: "{{ _nexus_repos_raw_defaults|combine(item) }}"

--- a/tasks/create_repo_raw_hosted_each.yml
+++ b/tasks/create_repo_raw_hosted_each.yml
@@ -1,5 +1,5 @@
 ---
-- include: call_script.yml
+- import_tasks: call_script.yml
   vars:
     script_name: create_repo_raw_hosted
     args: "{{ _nexus_repos_raw_defaults|combine(item) }}"

--- a/tasks/create_repo_raw_proxy_each.yml
+++ b/tasks/create_repo_raw_proxy_each.yml
@@ -1,5 +1,5 @@
 ---
-- include: call_script.yml
+- import_tasks: call_script.yml
   vars:
     script_name: create_repo_raw_proxy
     args: "{{ _nexus_repos_raw_defaults|combine(item) }}"

--- a/tasks/create_repo_rubygems_group_each.yml
+++ b/tasks/create_repo_rubygems_group_each.yml
@@ -1,5 +1,5 @@
 ---
-- include: call_script.yml
+- import_tasks: call_script.yml
   vars:
     script_name: create_repo_rubygems_group
     args: "{{ _nexus_repos_rubygems_defaults|combine(item) }}"

--- a/tasks/create_repo_rubygems_hosted_each.yml
+++ b/tasks/create_repo_rubygems_hosted_each.yml
@@ -1,5 +1,5 @@
 ---
-- include: call_script.yml
+- import_tasks: call_script.yml
   vars:
     script_name: create_repo_rubygems_hosted
     args: "{{ _nexus_repos_rubygems_defaults|combine(item) }}"

--- a/tasks/create_repo_rubygems_proxy_each.yml
+++ b/tasks/create_repo_rubygems_proxy_each.yml
@@ -1,5 +1,5 @@
 ---
-- include: call_script.yml
+- import_tasks: call_script.yml
   vars:
     script_name: create_repo_rubygems_proxy
     args: "{{ _nexus_repos_rubygems_defaults|combine(item) }}"

--- a/tasks/create_task_each.yml
+++ b/tasks/create_task_each.yml
@@ -1,5 +1,5 @@
 ---
-- include: call_script.yml
+- import_tasks: call_script.yml
   vars:
     script_name: create_task
     args: "{{ item }}"

--- a/tasks/delete_blobstore_each.yml
+++ b/tasks/delete_blobstore_each.yml
@@ -1,5 +1,5 @@
 ---
-- include: call_script.yml
+- import_tasks: call_script.yml
   vars:
     script_name: delete_blobstore
     args: "{{ item }}"

--- a/tasks/delete_repo_each.yml
+++ b/tasks/delete_repo_each.yml
@@ -1,5 +1,5 @@
 ---
-- include: call_script.yml
+- import_tasks: call_script.yml
   vars:
     script_name: delete_repo
     args:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,16 +1,16 @@
 ---
-- include: nexus_purge.yml
+- import_tasks: nexus_purge.yml
   when: ((purge is defined) and (purge | bool))
 
-- include: nexus_install.yml
+- import_tasks: nexus_install.yml
 
-- include: httpd_reverse_proxy_config.yml
+- import_tasks: httpd_reverse_proxy_config.yml
   when: httpd_setup_enable
 
-- include: admin_password_setup.yml
+- import_tasks: admin_password_setup.yml
 
 - name: Deleting default repositories
-  include: delete_repo_each.yml
+  include_tasks: delete_repo_each.yml
   with_items:
     - maven-central
     - maven-public
@@ -22,7 +22,7 @@
   when: nexus_data_dir_contents.stdout == "" and nexus_delete_default_repos
 
 - name: Deleting default blobstore
-  include: delete_blobstore_each.yml
+  include_tasks: delete_blobstore_each.yml
   with_items:
     - name: default
     - name: "{{ nexus_blob_names.raw.blob }}"
@@ -35,122 +35,122 @@
     - name: "{{ nexus_blob_names.gitlfs.blob }}"
   when: nexus_data_dir_contents.stdout == "" and nexus_delete_default_blobstore
 
-- include: setup_ldap_each.yml
+- include_tasks: setup_ldap_each.yml
   with_items: "{{ ldap_connections }}"
 
-- include: setup_privilege_each.yml
+- include_tasks: setup_privilege_each.yml
   with_items: "{{ nexus_privileges }}"
 
-- include: setup_role_each.yml
+- include_tasks: setup_role_each.yml
   with_items: "{{ nexus_roles }}"
 
-- include: setup_user_each.yml
+- include_tasks: setup_user_each.yml
   with_items: "{{ nexus_local_users }}"
 
 - name: "Digest splited blob list var"
   include_vars: blob_vars.yml
   when: nexus_blob_split
 
-- include: create_blobstore_each.yml
+- include_tasks: create_blobstore_each.yml
   with_items: "{{ nexus_blobstores }}"
   when: nexus_restore_point is undefined
 
 - name: "Restore nexus backup"
-  include: nexus-restore.yml
+  import_tasks: nexus-restore.yml
   when: nexus_restore_point is defined
 
-- include: create_repo_maven_proxy_each.yml
+- include_tasks: create_repo_maven_proxy_each.yml
   with_items: "{{ nexus_repos_maven_proxy }}"
 
-- include: create_repo_maven_hosted_each.yml
+- include_tasks: create_repo_maven_hosted_each.yml
   with_items: "{{ nexus_repos_maven_hosted }}"
 
-- include: create_repo_maven_group_each.yml
+- include_tasks: create_repo_maven_group_each.yml
   with_items: "{{ nexus_repos_maven_group }}"
 
 - block:
-  - include: create_repo_docker_hosted_each.yml
+  - include_tasks: create_repo_docker_hosted_each.yml
     with_items: "{{ nexus_repos_docker_hosted }}"
 
-  - include: create_repo_docker_proxy_each.yml
+  - include_tasks: create_repo_docker_proxy_each.yml
     with_items: "{{ nexus_repos_docker_proxy }}"
 
-  - include: create_repo_docker_group_each.yml
+  - include_tasks: create_repo_docker_group_each.yml
     with_items: "{{ nexus_repos_docker_group }}"
   when: nexus_config_docker
 
 - block:
-  - include: create_repo_pypi_proxy_each.yml
+  - include_tasks: create_repo_pypi_proxy_each.yml
     with_items: "{{ nexus_repos_pypi_proxy }}"
 
-  - include: create_repo_pypi_hosted_each.yml
+  - include_tasks: create_repo_pypi_hosted_each.yml
     with_items: "{{ nexus_repos_pypi_hosted }}"
 
-  - include: create_repo_pypi_group_each.yml
+  - include_tasks: create_repo_pypi_group_each.yml
     with_items: "{{ nexus_repos_pypi_group }}"
   when: nexus_config_pypi
 
 - block:
-  - include: create_repo_raw_proxy_each.yml
+  - include_tasks: create_repo_raw_proxy_each.yml
     with_items: "{{ nexus_repos_raw_proxy }}"
 
-  - include: create_repo_raw_hosted_each.yml
+  - include_tasks: create_repo_raw_hosted_each.yml
     with_items: "{{ nexus_repos_raw_hosted }}"
 
-  - include: create_repo_raw_group_each.yml
+  - include_tasks: create_repo_raw_group_each.yml
     with_items: "{{ nexus_repos_raw_group }}"
   when: nexus_config_raw
 
 - block:
-  - include: create_repo_rubygems_proxy_each.yml
+  - include_tasks: create_repo_rubygems_proxy_each.yml
     with_items: "{{ nexus_repos_rubygems_proxy }}"
 
-  - include: create_repo_rubygems_hosted_each.yml
+  - include_tasks: create_repo_rubygems_hosted_each.yml
     with_items: "{{ nexus_repos_rubygems_hosted }}"
 
-  - include: create_repo_rubygems_group_each.yml
+  - include_tasks: create_repo_rubygems_group_each.yml
     with_items: "{{ nexus_repos_rubygems_group }}"
   when: nexus_config_rubygems
 
 - block:
-  - include: create_repo_bower_proxy_each.yml
+  - include_tasks: create_repo_bower_proxy_each.yml
     with_items: "{{ nexus_repos_bower_proxy }}"
 
-  - include: create_repo_bower_hosted_each.yml
+  - include_tasks: create_repo_bower_hosted_each.yml
     with_items: "{{ nexus_repos_bower_hosted }}"
 
-  - include: create_repo_bower_group_each.yml
+  - include_tasks: create_repo_bower_group_each.yml
     with_items: "{{ nexus_repos_bower_group }}"
   when: nexus_config_bower
 
 - block:
-  - include: create_repo_npm_proxy_each.yml
+  - include_tasks: create_repo_npm_proxy_each.yml
     with_items: "{{ nexus_repos_npm_proxy }}"
 
-  - include: create_repo_npm_hosted_each.yml
+  - include_tasks: create_repo_npm_hosted_each.yml
     with_items: "{{ nexus_repos_npm_hosted }}"
 
-  - include: create_repo_npm_group_each.yml
+  - include_tasks: create_repo_npm_group_each.yml
     with_items: "{{ nexus_repos_npm_group }}"
   when: nexus_config_npm
 
-- include: create_repo_gitlfs_hosted_each.yml
+- include_tasks: create_repo_gitlfs_hosted_each.yml
   with_items: "{{ nexus_repos_gitlfs_hosted }}"
   when: nexus_config_gitlfs
 
-- include: call_script.yml
+- import_tasks: call_script.yml
   vars:
     script_name: setup_anonymous_access
     args:
       anonymous_access: "{{ nexus_anonymous_access }}"
 
-- include: call_script.yml
+- import_tasks: call_script.yml
   vars:
     script_name: setup_base_url
     args:
       base_url: "https://{{ public_hostname }}/"
 
-- include: call_script.yml
+- import_tasks: call_script.yml
   vars:
     script_name: setup_http_proxy
     args:
@@ -167,7 +167,7 @@
       proxy_exclude_hosts: "{{ nexus_proxy_exclude_hosts }}"
 
 - name: Configure branding capability
-  include: call_script.yml
+  import_tasks: call_script.yml
   vars:
     script_name: setup_capability
     args:
@@ -178,5 +178,5 @@
         footerEnabled: "{{ nexus_branding_footer != '' }}"
         headerEnabled: "{{ nexus_branding_header != '' }}"
 
-- include: create_task_each.yml
+- include_tasks: create_task_each.yml
   with_items: "{{ nexus_scheduled_tasks }}"

--- a/tasks/nexus_install.yml
+++ b/tasks/nexus_install.yml
@@ -250,7 +250,7 @@
   when: nexus_data_dir_contents.stdout != ""
   no_log: true
 
-- include: declare_script_each.yml
+- include_tasks: declare_script_each.yml
   with_items:
     - update_admin_password
     - setup_ldap

--- a/tasks/setup_ldap_each.yml
+++ b/tasks/setup_ldap_each.yml
@@ -1,5 +1,5 @@
 ---
-- include: call_script.yml
+- import_tasks: call_script.yml
   vars:
     script_name: setup_ldap
     args:

--- a/tasks/setup_privilege_each.yml
+++ b/tasks/setup_privilege_each.yml
@@ -1,5 +1,5 @@
 ---
-- include: call_script.yml
+- import_tasks: call_script.yml
   vars:
     script_name: setup_privilege
     args: "{{ _nexus_privilege_defaults|combine(item) }}"

--- a/tasks/setup_role_each.yml
+++ b/tasks/setup_role_each.yml
@@ -1,5 +1,5 @@
 ---
-- include: call_script.yml
+- import_tasks: call_script.yml
   vars:
     script_name: setup_role
     args: "{{ item }}"

--- a/tasks/setup_user_each.yml
+++ b/tasks/setup_user_each.yml
@@ -1,5 +1,5 @@
 ---
-- include: call_script.yml
+- import_tasks: call_script.yml
   vars:
     script_name: setup_user
     args: "{{ item }}"


### PR DESCRIPTION
Flaged as WIP because this is a backward incompatible change for ansible < 2.4. Meanwhile this change will be necessary at some point for future releases (if I understood the ansible roadmap correctly, before ansible 2.8 is out). Just to let you know this was tested briefly on my side and I was able to deploy nexus with these changes.

The include module has been deprecated in ansible 2.4
and must be replaced by import_tasks or include_tasks
to get tasks from an other yml file