### PR TITLE
Permissions of scripts were being set non-executable.

### DIFF
--- a/tasks/nexus_install.yml
+++ b/tasks/nexus_install.yml
@@ -226,7 +226,7 @@
     path: "{{ nexus_installation_dir }}/nexus-latest/etc"
     owner: "root"
     group: "root"
-    mode: "0644"
+    mode: a=rX,u+w
     recurse: true
 
 - name: Prevent nexus to create any new configuration files in  {{ nexus_installation_dir }}/nexus-latest/etc


### PR DESCRIPTION
The "Deploy Scripts" task was setting the scripts permissions
correctly, then the "Chown configuration files" task was setting
them to 644, making them non-executable.  This uses the symbolic
permission "X" which preserves executable if it already has x.